### PR TITLE
Fix for macros not running in variable queries.

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -57,8 +57,8 @@ export class JsonDataSource extends DataSourceApi<JsonApiQuery, JsonApiDataSourc
    *
    * @param query
    */
-  async metricFindQuery?(query: JsonApiQuery): Promise<MetricFindValue[]> {
-    const frames = await this.doRequest(query);
+  async metricFindQuery?(query: JsonApiQuery, options: Record<string, any>): Promise<MetricFindValue[]> {
+    const frames = await this.doRequest(query, options.range);
     const frame = frames[0];
 
     if (!frame.fields.length) {


### PR DESCRIPTION
Apologies for being a couple of days late in submitting this.  This fixes #98, where macros do not run in variable queries.