### PR TITLE
Adding `$__isoFrom()` and `$__isoTo()` macros

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,0 +1,24 @@
+import { replaceMacros } from './datasource';
+import { TimeRange, dateTime } from '@grafana/data';
+
+const sampleTimestampFrom = '2021-05-17T20:48:09.000Z'; // -> 1621284489
+const sampleTimestmapTo = '2021-05-17T20:50:23.000Z'; // -> 1621284623
+
+const range: TimeRange = {
+  from: dateTime(sampleTimestampFrom),
+  to: dateTime(sampleTimestmapTo),
+  raw: {
+    from: sampleTimestampFrom,
+    to: sampleTimestmapTo,
+  },
+};
+
+test('range gets converted into ISO8601 notation', () => {
+  expect(replaceMacros('$__isoFrom()', range)).toStrictEqual(sampleTimestampFrom);
+  expect(replaceMacros('$__isoTo()', range)).toStrictEqual(sampleTimestmapTo);
+});
+
+test('range gets converted into unix epoch notation', () => {
+  expect(replaceMacros('$__unixEpochFrom()', range)).toStrictEqual('1621284489');
+  expect(replaceMacros('$__unixEpochTo()', range)).toStrictEqual('1621284623');
+});

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -209,11 +209,13 @@ const replace = (scopedVars?: any, range?: TimeRange) => (str: string): string =
 };
 
 // replaceMacros substitutes all available macros with their current value.
-const replaceMacros = (str: string, range?: TimeRange) => {
+export const replaceMacros = (str: string, range?: TimeRange) => {
   return range
     ? str
         .replace(/\$__unixEpochFrom\(\)/g, range.from.unix().toString())
         .replace(/\$__unixEpochTo\(\)/g, range.to.unix().toString())
+        .replace(/\$__isoFrom\(\)/g, range.from.toISOString())
+        .replace(/\$__isoTo\(\)/g, range.to.toISOString())
     : str;
 };
 

--- a/website/docs/macros.md
+++ b/website/docs/macros.md
@@ -5,7 +5,9 @@ title: Macros
 
 Use macros to add dashboard context to your queries. Macros are available in HTTP params and JSONPath expressions.
 
-| Macro                | Description                                                               |
-|----------------------|---------------------------------------------------------------------------|
-| `$__unixEpochFrom()` | Start of the dashboard time interval as a Unix timestamp, i.e. 1494410783 |
-| `$__unixEpochTo()`   | End of the dashboard time interval as a Unix timestamp, i.e. 1494410783   |
+| Macro                | Description                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------ |
+| `$__unixEpochFrom()` | Start of the dashboard time interval as a Unix timestamp, i.e. 1494410783                  |
+| `$__unixEpochTo()`   | End of the dashboard time interval as a Unix timestamp, i.e. 1494410783                    |
+| `$__isoFrom()`       | Start of the dashboard time interval as a ISO8601 timestamp, i.e. 2021-05-17T20:48:09.000Z |
+| `$__isoTo()`         | End of the dashboard time interval as a ISO8601 timestamp, i.e. 2021-05-17T20:48:09.000Z   |


### PR DESCRIPTION
Hi, the service which I want to query doesn't support epoch timestamp but rather ISO8601. Would it be a problem to include these macros?