### PR TITLE
Append suffix to param key to uniquify duplicate param keys

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -26,10 +26,14 @@ export default class Api {
     body?: string
   ) {
     const paramsData: Record<string, string> = {};
-
+    // In order to allow for duplicate URL params add a suffix to it to
+    // uniquify the key.  We strip this suffix off as part of
+    // constructing the final URL in _request()
+    let i = 0;
     (params ?? []).forEach(([key, value]) => {
       if (key) {
-        paramsData[key] = value;
+        paramsData[key + '__' + i] = value;
+        i++;
       }
     });
 
@@ -140,7 +144,7 @@ export default class Api {
         req.url +
         (req.url.search(/\?/) >= 0 ? '&' : '?') +
         Object.entries(params)
-          .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+          .map(([k, v]) => `${encodeURIComponent(k.replace(/__\d+$/, ''))}=${encodeURIComponent(v)}`)
           .join('&');
     }
 


### PR DESCRIPTION
Fixes #169

This PR is my attempt to address [issue 169](https://github.com/marcusolsson/grafana-json-datasource/issues/169).

Apologies in advance if this proposed fix is too naive - It's been awhile since I've done any JS coding.  The fix simply appends a suffix to the param name (key) for each param before adding it to the `paramsData` map.  It then strips the suffix off before constructing the request URL in `_request()`.  I tested this change by loading the plugin in a local grafana instance and modifying an existing dashboard we have for viewing Prometheus alerts - which uses this plugin - to make API calls to Alertmanager.  I then repeatedly added/removed various combinations of request parameters (including params with duplicate keys) via the Grafana UI and then verified in each case that the final constructed URL string looked as expected by intercepting the requests using a simple proxy that was placed in front of Alertmamager which would dump the request URL before forwarding the request. 

I also ran the unit tests in the repo (output captured below):

```
$ yarn test
yarn run v1.22.17
$ grafana-toolkit plugin:test
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead
ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead
ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead
 PASS  src/detectFieldType.test.ts
 PASS  src/parseValues.test.ts
 PASS  src/datasource.test.ts

Test Suites: 3 passed, 3 total
Tests:       20 passed, 20 total
Snapshots:   0 total
Time:        1.752 s, estimated 2 s
Ran all test suites with tests matching "".
✔ Running tests
Done in 2.84s.
```
