### PR TITLE
groupBy: support non-strings

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -265,7 +265,7 @@ export const groupBy = (frame: DataFrame, fieldName: string): DataFrame[] => {
     return [frame];
   }
 
-  const uniqueValues = new Set<string>(groupByField.values.toArray().map((value) => value.toString()));
+  const uniqueValues = new Set(groupByField.values.toArray());
 
   const frames = [...uniqueValues].map((groupByValue) => {
     const fields: Field[] = frame.fields


### PR DESCRIPTION
previously, group-by coerced all values into strings for comparison, but
only for the left-hand side, effectively resulting into groupBy being
only usable with strings.

by changing the set type to literal "any", this limitation is removed.